### PR TITLE
Minor fixes for strfry

### DIFF
--- a/src/test_item.rs
+++ b/src/test_item.rs
@@ -152,7 +152,7 @@ impl TestItem {
             ClaimsSupportForNip29 => "Claims support for NIP-29 (Relay-based Groups)",
             ClaimsSupportForNip40 => "Claims support for NIP-40 (Expiration Timestamp)",
             ClaimsSupportForNip42 => "Claims support for NIP-42 (AUTH)",
-            ClaimsSupportForNip45 => "Claims supprort for NIP-45 (COUNT)",
+            ClaimsSupportForNip45 => "Claims support for NIP-45 (COUNT)",
             ClaimsSupportForNip50 => "Claims support for NIP-50 (SEARCH)",
             ClaimsSupportForNip59 => "Claims support for NIP-59 (Giftwrap)",
             ClaimsSupportForNip65 => "Claims support for NIP-65 (Relay Lists)",

--- a/src/tests/delete.rs
+++ b/src/tests/delete.rs
@@ -1,16 +1,274 @@
+use super::{minutes_ago, tags};
+use crate::WAIT;
 use crate::error::Error;
+use crate::globals::{EventParts, Globals, GLOBALS};
 use crate::outcome::Outcome;
+use nostr_types::{EventKind, Filter, NAddr};
+use std::time::Duration;
 
 pub async fn delete_by_id() -> Result<Outcome, Error> {
-    Ok(Outcome::err("NOT YET IMPLEMENTED".to_string()))
+    // Make an event
+    let event = Globals::make_event(
+        EventParts::Basic(EventKind::TextNote, tags(&[&["test"]]), "I say wrong thing".to_string()),
+        true,
+    )?;
+    let event_id = event.id;
+
+    // Submit it
+    let (ok, reason) = GLOBALS
+        .connection
+        .write()
+        .as_mut()
+        .unwrap()
+        .post_event(event, Duration::from_secs(WAIT))
+        .await?;
+    if !ok {
+        return Ok(Outcome::err(reason));
+    }
+
+    // Make a deletion event, e-tag
+    let delete_event = Globals::make_event(
+        EventParts::Basic(
+            EventKind::EventDeletion,
+            tags(&[&["e", &event_id.as_hex_string()]]),
+            "".to_string()
+        ),
+        true,
+    )?;
+
+    // Submit it
+    let (ok, reason) = GLOBALS
+        .connection
+        .write()
+        .as_mut()
+        .unwrap()
+        .post_event(delete_event, Duration::from_secs(WAIT))
+        .await?;
+    if !ok {
+        return Ok(Outcome::err(reason));
+    }
+
+    // Fetch back the original event
+    let mut filter = Filter::new();
+    filter.ids = vec![event_id.into()];
+    let events = GLOBALS
+        .connection
+        .write()
+        .as_mut()
+        .unwrap()
+        .fetch_events(vec![filter], Duration::from_secs(WAIT))
+        .await?
+        .into_events();
+
+    if events.is_empty() {
+        Ok(Outcome::pass(None))
+    } else {
+        Ok(Outcome::fail(Some("Deleted event did not get deleted".to_owned())))
+    }
 }
 
 pub async fn delete_by_addr() -> Result<Outcome, Error> {
-    Ok(Outcome::err("NOT YET IMPLEMENTED".to_string()))
+    // Make an event
+    let event = Globals::make_event(
+        EventParts::Basic(
+            EventKind::LongFormContent,
+            tags(&[
+                &["d", "delete_by_addr_test"],
+            ]),
+            "I say wrong thing".to_string()
+        ),
+        true,
+    )?;
+    let event_id = event.id;
+
+    // Compute event group address
+    let naddr = NAddr {
+        d: "delete_by_addr_test".to_owned(),
+        relays: vec![],
+        kind: EventKind::LongFormContent,
+        author: event.pubkey,
+    };
+    let a_tag = format!(
+        "{}:{}:{}",
+        Into::<u32>::into(naddr.kind),
+        naddr.author.as_hex_string(),
+        naddr.d
+    );
+
+    // Submit it
+    let (ok, reason) = GLOBALS
+        .connection
+        .write()
+        .as_mut()
+        .unwrap()
+        .post_event(event, Duration::from_secs(WAIT))
+        .await?;
+    if !ok {
+        return Ok(Outcome::err(reason));
+    }
+
+    // Make a deletion event, a-tag
+    let delete_event = Globals::make_event(
+        EventParts::Basic(
+            EventKind::EventDeletion,
+            tags(&[
+                &["a", &a_tag]
+            ]),
+            "".to_string()
+        ),
+        true,
+    )?;
+
+    // Submit it
+    let (ok, reason) = GLOBALS
+        .connection
+        .write()
+        .as_mut()
+        .unwrap()
+        .post_event(delete_event, Duration::from_secs(WAIT))
+        .await?;
+    if !ok {
+        return Ok(Outcome::err(reason));
+    }
+
+    // Fetch back the original event (by ID this time)
+    let mut filter = Filter::new();
+    filter.ids = vec![event_id.into()];
+    let events = GLOBALS
+        .connection
+        .write()
+        .as_mut()
+        .unwrap()
+        .fetch_events(vec![filter], Duration::from_secs(WAIT))
+        .await?
+        .into_events();
+
+    if events.is_empty() {
+        Ok(Outcome::pass(None))
+    } else {
+        Ok(Outcome::fail(Some("Deleted event did not get deleted".to_owned())))
+    }
 }
 
 pub async fn delete_by_addr_only_older() -> Result<Outcome, Error> {
-    Ok(Outcome::err("NOT YET IMPLEMENTED".to_string()))
+    // Prepare some times
+    let time1 = minutes_ago(5);
+    let time2 = minutes_ago(3);
+    let time3 = minutes_ago(1);
+
+    // Make an event, time1
+    let event1 = Globals::make_event(
+        EventParts::Dated(
+            EventKind::LongFormContent,
+            tags(&[
+                &["d", "delete_by_addr_only_older_test"],
+            ]),
+            "I say wrong thing".to_string(),
+            time1,
+        ),
+        true,
+    )?;
+    let event1_id = event1.id;
+
+    // Compute event group address
+    let naddr = NAddr {
+        d: "delete_by_addr_only_older_test".to_owned(),
+        relays: vec![],
+        kind: EventKind::LongFormContent,
+        author: event1.pubkey,
+    };
+    let a_tag = format!(
+        "{}:{}:{}",
+        Into::<u32>::into(naddr.kind),
+        naddr.author.as_hex_string(),
+        naddr.d
+    );
+
+    // Submit it
+    let (ok, reason) = GLOBALS
+        .connection
+        .write()
+        .as_mut()
+        .unwrap()
+        .post_event(event1, Duration::from_secs(WAIT))
+        .await?;
+    if !ok {
+        return Ok(Outcome::err(reason));
+    }
+
+    // Make an event, time3
+    let event3 = Globals::make_event(
+        EventParts::Dated(
+            EventKind::LongFormContent,
+            tags(&[
+                &["d", "delete_by_addr_only_older_test"],
+            ]),
+            "I say right thing".to_string(),
+            time3,
+        ),
+        true,
+    )?;
+    let event3_id = event3.id;
+
+    // Submit it
+    let (ok, reason) = GLOBALS
+        .connection
+        .write()
+        .as_mut()
+        .unwrap()
+        .post_event(event3, Duration::from_secs(WAIT))
+        .await?;
+    if !ok {
+        return Ok(Outcome::err(reason));
+    }
+
+    tokio::time::sleep(Duration::from_secs(1)).await;
+
+    // Make a deletion event, a-tag
+    let delete_event = Globals::make_event(
+        EventParts::Dated(
+            EventKind::EventDeletion,
+            tags(&[
+                &["a", &a_tag]
+            ]),
+            "".to_string(),
+            time2,
+        ),
+        true,
+    )?;
+
+    // Submit it
+    let (ok, reason) = GLOBALS
+        .connection
+        .write()
+        .as_mut()
+        .unwrap()
+        .post_event(delete_event, Duration::from_secs(WAIT))
+        .await?;
+    if !ok {
+        return Ok(Outcome::err(reason));
+    }
+
+    // Fetch back the events in this event group
+    let mut filter = Filter::new();
+    filter.add_tag_value('a', a_tag);
+    let events = GLOBALS
+        .connection
+        .write()
+        .as_mut()
+        .unwrap()
+        .fetch_events(vec![filter], Duration::from_secs(WAIT))
+        .await?
+        .into_events();
+
+    // We SHOULD have just event3, not event1
+    if events.iter().any(|e| e.id == event1_id) {
+        Ok(Outcome::fail(Some("Failed to delete older event by a-tag".to_owned())))
+    } else if ! events.iter().any(|e| e.id == event3_id) {
+        Ok(Outcome::fail(Some("Wrongly deleted a-tag event newer than delete event".to_owned())))
+    } else {
+        Ok(Outcome::pass(None))
+    }
 }
 
 pub async fn delete_by_addr_bound_by_tag() -> Result<Outcome, Error> {

--- a/src/tests/find.rs
+++ b/src/tests/find.rs
@@ -165,7 +165,7 @@ pub async fn find_by_kind_and_tags() -> Result<Outcome, Error> {
         let mut filter = Filter::new();
         filter.kinds = vec![
             EventKind::TextNote,
-            EventKind::Other(30383),
+            EventKind::Other(40383),
             EventKind::ContactList,
         ];
         filter.add_tag_value('n', "approved".to_string());
@@ -195,7 +195,7 @@ pub async fn find_by_multiple_tags() -> Result<Outcome, Error> {
     let filter = {
         let mut filter = Filter::new();
         let pkh: PublicKeyHex = registered_public_key.into();
-        filter.add_event_kind(EventKind::Other(30383));
+        filter.add_event_kind(EventKind::Other(40383));
         filter.add_author(&pkh);
         filter.add_tag_value('k', "3036".to_string());
         filter.add_tag_value('n', "approved".to_string());

--- a/src/tests/find.rs
+++ b/src/tests/find.rs
@@ -269,7 +269,7 @@ async fn find(filter: Filter, num_matches_expected: Option<usize>) -> Result<Out
                         e
                     ))));
                 } else {
-                    return Ok(Outcome::fail(Some("Expected event is missing".to_owned())));
+                    return Ok(Outcome::fail(Some(format!("Expected event is missing: {}", findable_event.id.as_hex_string()))));
                 }
             }
             matches += 1;

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -171,7 +171,7 @@ async fn maybe_submit_event_group_a_inner() -> Result<(), Error> {
     lock.insert(
         "multipletags",
         EventParts::Dated(
-            EventKind::Other(30383),
+            EventKind::Other(40383),
             tags(&[&["k", "3036"], &["n", "approved"]]),
             "multipletags".to_owned(),
             minutes_ago(10),
@@ -183,7 +183,7 @@ async fn maybe_submit_event_group_a_inner() -> Result<(), Error> {
     lock.insert(
         "multipletags_shouldntmatch",
         EventParts::Dated(
-            EventKind::Other(30383),
+            EventKind::Other(40383),
             tags(&[&["n", "approved"]]),
             "multipletags_shouldntmatch".to_owned(),
             minutes_ago(10),

--- a/src/tests/time.rs
+++ b/src/tests/time.rs
@@ -67,7 +67,7 @@ fn minutes_ago(m: u64) -> Unixtime {
 
 async fn doit(u: Unixtime) -> Result<Outcome, Error> {
     let event = Globals::make_event(
-        EventParts::Dated(EventKind::TextNote, tags(&[&[]]), "".to_owned(), u),
+        EventParts::Dated(EventKind::TextNote, tags(&[]), "".to_owned(), u),
         true,
     )?;
 


### PR DESCRIPTION
Very cool test-suite! I ran it against strfry and encountered some minor issues, which I have fixed. I guess a couple of them are open for interpretation, but I believe strfry implements allowable behavour in these cases so the test-suite should be adjusted:

* Always rejects empty tags (ie `"tags":[[]]`)
* Treats PRE (events in the 30k range) without a `d` tag as replaceable, and therefore deletes the previous